### PR TITLE
updated allnews.md to prevent the html tags

### DIFF
--- a/_pages/allnews.md
+++ b/_pages/allnews.md
@@ -9,5 +9,5 @@ permalink: /allnews.html
 # News
 
 {% for article in site.data.news %}
-<p>{{ article.date }} <br> {{ article.headline | markdownify}}</p>
+<p>{{ article.date }} <br> {{ article.headline }}</p>
 {% endfor %}


### PR DESCRIPTION
#### Description
- '| markdowinify' was causing the html tags to be rendered in the allnews page


#### Changes
- Removed it