### PR TITLE
Add Events, Talks, Grants pages and social/newsletter automation

### DIFF
--- a/.github/scripts/generate_newsletter.py
+++ b/.github/scripts/generate_newsletter.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""
+Weekly newsletter draft generator.
+Reads _data/ YAML files, builds a Markdown digest, and creates a GitHub Issue.
+Triggered by .github/workflows/newsletter.yml every Monday at 08:00 UTC.
+"""
+
+import os
+import json
+import datetime
+import requests
+import yaml
+from dateutil import parser as dateparser
+
+REPO = os.environ["GITHUB_REPOSITORY"]
+GH_TOKEN = os.environ["GITHUB_TOKEN"]
+SITE_URL = "https://aicentre-csg.github.io"  # update to your actual GitHub Pages URL
+
+DATA_DIR = "_data"
+LOOKAHEAD_DAYS = 14   # upcoming events/talks window
+LOOKBACK_DAYS = 7     # recent news/papers window
+
+
+def load_yaml(filename):
+    path = os.path.join(DATA_DIR, filename)
+    if not os.path.exists(path):
+        return []
+    with open(path, encoding="utf-8") as f:
+        return yaml.safe_load(f) or []
+
+
+def parse_date(date_str):
+    """Parse various date string formats into a date object. Returns None on failure."""
+    if not date_str:
+        return None
+    try:
+        return dateparser.parse(str(date_str)).date()
+    except Exception:
+        return None
+
+
+def build_newsletter():
+    today = datetime.date.today()
+    lookahead = today + datetime.timedelta(days=LOOKAHEAD_DAYS)
+    lookback = today - datetime.timedelta(days=LOOKBACK_DAYS)
+
+    events = load_yaml("events.yml")
+    talks = load_yaml("talks.yml")
+    news = load_yaml("news.yml")
+    publist = load_yaml("publist.yml")
+    grants = load_yaml("grants.yml")
+
+    lines = [
+        f"# 📰 AI Centre@CSG — Newsletter Draft {today.strftime('%d %B %Y')}",
+        "",
+        "> *Auto-generated draft. Review and edit before sending.*",
+        "",
+    ]
+
+    # ── Upcoming Events & Talks ──────────────────────────────────────────────
+    upcoming = []
+    for item in events:
+        d = parse_date(item.get("date"))
+        if d and today <= d <= lookahead:
+            upcoming.append(("event", d, item))
+    for item in talks:
+        d = parse_date(item.get("date"))
+        if d and today <= d <= lookahead:
+            upcoming.append(("talk", d, item))
+    upcoming.sort(key=lambda x: x[1])
+
+    lines.append("## 📅 Upcoming Events & Talks (next 2 weeks)")
+    lines.append("")
+    if upcoming:
+        for kind, d, item in upcoming:
+            if kind == "event":
+                title = item.get("title", "")
+                link = item.get("link", "")
+                loc = item.get("location", "")
+                speaker = item.get("speaker", "")
+                etype = item.get("type", "")
+                label = f"**{d.strftime('%-d %B')}** — [{title}]({link})" if link else f"**{d.strftime('%-d %B')}** — {title}"
+                detail = " | ".join(filter(None, [etype.capitalize() if etype else "", speaker, loc]))
+                lines.append(f"- {label}")
+                if detail:
+                    lines.append(f"  *{detail}*")
+            else:  # talk
+                title = item.get("title", "")
+                speaker = item.get("speaker", "")
+                affil = item.get("affiliation", "")
+                speaker_str = f"{speaker}, {affil}" if affil else speaker
+                lines.append(f"- **{d.strftime('%-d %B')}** — {title}")
+                lines.append(f"  *Talk by {speaker_str}*")
+        lines.append("")
+    else:
+        lines.append("*No events or talks in the next two weeks.*")
+        lines.append("")
+
+    # ── Recent News ──────────────────────────────────────────────────────────
+    recent_news = []
+    for item in news:
+        d = parse_date(item.get("date"))
+        if d and lookback <= d <= today:
+            recent_news.append((d, item.get("headline", "")))
+    recent_news.sort(key=lambda x: x[0], reverse=True)
+
+    lines.append("## 📢 Recent News (last 7 days)")
+    lines.append("")
+    if recent_news:
+        for d, headline in recent_news:
+            lines.append(f"- **{d.strftime('%-d %B')}** — {headline}")
+        lines.append("")
+    else:
+        lines.append("*No news items in the last 7 days.*")
+        lines.append("")
+
+    # ── New Papers ───────────────────────────────────────────────────────────
+    recent_papers = []
+    for pub in publist:
+        d = parse_date(pub.get("date"))
+        if d and lookback <= d <= today:
+            recent_papers.append((d, pub))
+    recent_papers.sort(key=lambda x: x[0], reverse=True)
+
+    lines.append("## 📄 New Papers (last 7 days)")
+    lines.append("")
+    if recent_papers:
+        for d, pub in recent_papers:
+            title = pub.get("title", "")
+            authors = pub.get("authors", "")
+            url = (pub.get("link") or {}).get("url", "")
+            venue = pub.get("book") or pub.get("journal") or pub.get("conference") or ""
+            title_str = f"[{title}]({url})" if url else title
+            lines.append(f"- **{d.strftime('%-d %B')}** — {title_str}")
+            if authors:
+                lines.append(f"  *{authors}*")
+            if venue:
+                lines.append(f"  {venue}")
+        lines.append("")
+    else:
+        lines.append("*No new papers in the last 7 days.*")
+        lines.append("")
+
+    # ── Active Grants ────────────────────────────────────────────────────────
+    active_grants = [g for g in grants if g.get("status") == "active"]
+
+    lines.append("## 💰 Active Grants")
+    lines.append("")
+    if active_grants:
+        for g in active_grants:
+            title = g.get("title", "")
+            funder = g.get("funder", "")
+            amount = g.get("amount", "")
+            pi = g.get("pi", "")
+            end = parse_date(g.get("end_date"))
+            end_str = end.strftime("%B %Y") if end else ""
+            detail = " | ".join(filter(None, [funder, amount, f"PI: {pi}" if pi else "", f"ends {end_str}" if end_str else ""]))
+            lines.append(f"- **{title}**")
+            if detail:
+                lines.append(f"  {detail}")
+        lines.append("")
+    else:
+        lines.append("*No active grants listed.*")
+        lines.append("")
+
+    lines.append("---")
+    lines.append(f"*Draft generated automatically on {today.strftime('%A %-d %B %Y')}.*")
+    lines.append(f"*Edit and send via your preferred email platform.*")
+
+    return "\n".join(lines)
+
+
+def ensure_label(headers):
+    """Create the 'newsletter-draft' label if it doesn't exist."""
+    url = f"https://api.github.com/repos/{REPO}/labels"
+    resp = requests.get(url, headers=headers)
+    existing = {l["name"] for l in resp.json()} if resp.ok else set()
+    if "newsletter-draft" not in existing:
+        requests.post(url, headers=headers, json={
+            "name": "newsletter-draft",
+            "color": "0075ca",
+            "description": "Auto-generated weekly newsletter draft",
+        })
+
+
+def create_issue(title, body):
+    headers = {
+        "Authorization": f"Bearer {GH_TOKEN}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    ensure_label(headers)
+    url = f"https://api.github.com/repos/{REPO}/issues"
+    payload = {"title": title, "body": body, "labels": ["newsletter-draft"]}
+    resp = requests.post(url, headers=headers, json=payload)
+    resp.raise_for_status()
+    issue = resp.json()
+    print(f"Created issue #{issue['number']}: {issue['html_url']}")
+
+
+if __name__ == "__main__":
+    today = datetime.date.today()
+    issue_title = f"📰 Newsletter Draft — {today.strftime('%Y-%m-%d')}"
+    body = build_newsletter()
+    create_issue(issue_title, body)

--- a/.github/scripts/post_social.py
+++ b/.github/scripts/post_social.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""
+Social media posting script.
+Detects new entries added to _data/ YAML files via git diff, formats a message
+per new item, and posts to Mastodon, Bluesky, X (Twitter), and LinkedIn.
+
+Set the environment variable SOCIAL_DRY_RUN=true to log messages without posting.
+
+Triggered by .github/workflows/social-media.yml on push to gh-pages.
+"""
+
+import os
+import re
+import subprocess
+import textwrap
+import yaml
+import requests
+
+DRY_RUN = os.environ.get("DRY_RUN", "").lower() == "true"
+SITE_URL = "https://aicentre-csg.github.io"  # update to your actual GitHub Pages URL
+HASHTAGS = "#AI #MachineLearning #Research #AICentre"
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+def git_diff_added_blocks(path):
+    """Return lines added in HEAD vs HEAD~1 for the given file path."""
+    result = subprocess.run(
+        ["git", "diff", "HEAD~1", "HEAD", "--", path],
+        capture_output=True, text=True
+    )
+    added = [l[1:] for l in result.stdout.splitlines() if l.startswith("+") and not l.startswith("+++")]
+    return "\n".join(added)
+
+
+def extract_new_entries(diff_text, all_entries, key_field):
+    """
+    Parse YAML diff lines to find new entries.
+    Falls back to returning entries whose key_field value appears in the diff.
+    """
+    new = []
+    for entry in (all_entries or []):
+        val = str(entry.get(key_field, ""))
+        if val and val in diff_text:
+            new.append(entry)
+    return new
+
+
+def truncate(text, max_len):
+    return text if len(text) <= max_len else text[:max_len - 1] + "…"
+
+
+def format_event(item):
+    title = item.get("title", "")
+    date = item.get("date", "")
+    location = item.get("location", "")
+    speaker = item.get("speaker", "")
+    link = item.get("link", "")
+    parts = [f"📅 {title}", f"📆 {date}"]
+    if speaker:
+        parts.append(f"🎤 {speaker}")
+    if location:
+        parts.append(f"📍 {location}")
+    if link:
+        parts.append(link)
+    parts.append(HASHTAGS)
+    return "\n".join(parts)
+
+
+def format_talk(item):
+    title = item.get("title", "")
+    date = item.get("date", "")
+    speaker = item.get("speaker", "")
+    affil = item.get("affiliation", "")
+    speaker_str = f"{speaker} ({affil})" if affil else speaker
+    parts = [f"🗣️ {title}", f"📆 {date}", f"👤 {speaker_str}", HASHTAGS]
+    return "\n".join(parts)
+
+
+def format_news(item):
+    headline = item.get("headline", "")
+    date = item.get("date", "")
+    # strip markdown links to plain text
+    plain = re.sub(r'\[([^\]]+)\]\([^)]+\)', r'\1', headline)
+    plain = re.sub(r'\*\*([^*]+)\*\*', r'\1', plain)
+    return f"📣 {plain}\n{date}\n{HASHTAGS}"
+
+
+def format_grant(item):
+    title = item.get("title", "")
+    funder = item.get("funder", "")
+    pi = item.get("pi", "")
+    amount = item.get("amount", "")
+    parts = [f"🏆 New grant: {title}", f"Funder: {funder}"]
+    if amount:
+        parts.append(f"Amount: {amount}")
+    if pi:
+        parts.append(f"PI: {pi}")
+    parts.append(HASHTAGS)
+    return "\n".join(parts)
+
+
+def format_paper(item):
+    title = item.get("title", "")
+    authors = item.get("authors", "")
+    venue = item.get("book") or item.get("journal") or item.get("conference") or ""
+    url = (item.get("link") or {}).get("url", "")
+    parts = [f"📄 New paper: {title}"]
+    if authors:
+        parts.append(authors)
+    if venue:
+        parts.append(venue)
+    if url:
+        parts.append(url)
+    parts.append(HASHTAGS)
+    return "\n".join(parts)
+
+
+# ── Platform Posters ─────────────────────────────────────────────────────────
+
+def post_mastodon(text):
+    instance = os.environ.get("MASTODON_INSTANCE_URL", "").rstrip("/")
+    token = os.environ.get("MASTODON_ACCESS_TOKEN", "")
+    if not (instance and token):
+        print("[Mastodon] Skipped — secrets not configured.")
+        return
+    msg = truncate(text, 500)
+    if DRY_RUN:
+        print(f"[DRY RUN Mastodon]\n{msg}\n")
+        return
+    resp = requests.post(
+        f"{instance}/api/v1/statuses",
+        headers={"Authorization": f"Bearer {token}"},
+        data={"status": msg, "visibility": "public"},
+    )
+    resp.raise_for_status()
+    print(f"[Mastodon] Posted: {resp.json().get('url')}")
+
+
+def post_bluesky(text):
+    handle = os.environ.get("BLUESKY_HANDLE", "")
+    password = os.environ.get("BLUESKY_APP_PASSWORD", "")
+    if not (handle and password):
+        print("[Bluesky] Skipped — secrets not configured.")
+        return
+    msg = truncate(text, 300)
+    if DRY_RUN:
+        print(f"[DRY RUN Bluesky]\n{msg}\n")
+        return
+    # Authenticate
+    auth = requests.post(
+        "https://bsky.social/xrpc/com.atproto.server.createSession",
+        json={"identifier": handle, "password": password},
+    )
+    auth.raise_for_status()
+    session = auth.json()
+    # Post
+    resp = requests.post(
+        "https://bsky.social/xrpc/com.atproto.repo.createRecord",
+        headers={"Authorization": f"Bearer {session['accessJwt']}"},
+        json={
+            "repo": session["did"],
+            "collection": "app.bsky.feed.post",
+            "record": {
+                "$type": "app.bsky.feed.post",
+                "text": msg,
+                "createdAt": __import__("datetime").datetime.utcnow().isoformat() + "Z",
+            },
+        },
+    )
+    resp.raise_for_status()
+    print(f"[Bluesky] Posted: {resp.json().get('uri')}")
+
+
+def post_twitter(text):
+    try:
+        import tweepy
+    except ImportError:
+        print("[X/Twitter] tweepy not installed.")
+        return
+    api_key = os.environ.get("TWITTER_API_KEY", "")
+    api_secret = os.environ.get("TWITTER_API_SECRET", "")
+    access_token = os.environ.get("TWITTER_ACCESS_TOKEN", "")
+    access_secret = os.environ.get("TWITTER_ACCESS_TOKEN_SECRET", "")
+    if not all([api_key, api_secret, access_token, access_secret]):
+        print("[X/Twitter] Skipped — secrets not configured.")
+        return
+    msg = truncate(text, 280)
+    if DRY_RUN:
+        print(f"[DRY RUN X/Twitter]\n{msg}\n")
+        return
+    client = tweepy.Client(
+        consumer_key=api_key,
+        consumer_secret=api_secret,
+        access_token=access_token,
+        access_token_secret=access_secret,
+    )
+    resp = client.create_tweet(text=msg)
+    print(f"[X/Twitter] Posted tweet ID: {resp.data['id']}")
+
+
+def post_linkedin(text):
+    token = os.environ.get("LINKEDIN_ACCESS_TOKEN", "")
+    person_urn = os.environ.get("LINKEDIN_PERSON_URN", "")
+    if not (token and person_urn):
+        print("[LinkedIn] Skipped — secrets not configured.")
+        return
+    msg = truncate(text, 3000)
+    if DRY_RUN:
+        print(f"[DRY RUN LinkedIn]\n{msg}\n")
+        return
+    resp = requests.post(
+        "https://api.linkedin.com/v2/ugcPosts",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "X-Restli-Protocol-Version": "2.0.0",
+        },
+        json={
+            "author": person_urn,
+            "lifecycleState": "PUBLISHED",
+            "specificContent": {
+                "com.linkedin.ugc.ShareContent": {
+                    "shareCommentary": {"text": msg},
+                    "shareMediaCategory": "NONE",
+                }
+            },
+            "visibility": {"com.linkedin.ugc.MemberNetworkVisibility": "PUBLIC"},
+        },
+    )
+    resp.raise_for_status()
+    print(f"[LinkedIn] Posted.")
+
+
+def post_all(text):
+    post_mastodon(text)
+    post_bluesky(text)
+    post_twitter(text)
+    post_linkedin(text)
+
+
+# ── Main ─────────────────────────────────────────────────────────────────────
+
+FILE_CONFIG = [
+    ("_data/events.yml",  "events.yml",  "title",    format_event),
+    ("_data/talks.yml",   "talks.yml",   "title",    format_talk),
+    ("_data/news.yml",    "news.yml",    "headline", format_news),
+    ("_data/grants.yml",  "grants.yml",  "title",    format_grant),
+    ("_data/publist.yml", "publist.yml", "title",    format_paper),
+]
+
+
+def load_yaml(filename):
+    if not os.path.exists(filename):
+        return []
+    with open(filename, encoding="utf-8") as f:
+        return yaml.safe_load(f) or []
+
+
+if __name__ == "__main__":
+    print(f"DRY_RUN={DRY_RUN}")
+    posted = 0
+    for git_path, data_file, key_field, formatter in FILE_CONFIG:
+        diff = git_diff_added_blocks(git_path)
+        if not diff.strip():
+            continue
+        all_entries = load_yaml(os.path.join("_data", data_file))
+        new_entries = extract_new_entries(diff, all_entries, key_field)
+        if not new_entries:
+            print(f"[{data_file}] No new entries detected.")
+            continue
+        # Batch multiple new entries from the same file into one message
+        # to stay within X free-tier limits
+        if len(new_entries) == 1:
+            msg = formatter(new_entries[0])
+            print(f"[{data_file}] Posting 1 new entry.")
+            post_all(msg)
+            posted += 1
+        else:
+            # Post a summary when multiple entries were added at once
+            titles = [e.get(key_field, "") for e in new_entries]
+            summary = f"📣 {len(new_entries)} new items added to {data_file.replace('.yml','')}:\n"
+            summary += "\n".join(f"• {t}" for t in titles[:5])
+            summary += f"\n{SITE_URL}\n{HASHTAGS}"
+            print(f"[{data_file}] Posting summary of {len(new_entries)} new entries.")
+            post_all(truncate(summary, 280))
+            posted += 1
+
+    if posted == 0:
+        print("No new data entries detected — nothing to post.")

--- a/.github/workflows/newsletter.yml
+++ b/.github/workflows/newsletter.yml
@@ -1,0 +1,33 @@
+name: Weekly Newsletter Draft
+
+on:
+  schedule:
+    # Every Monday at 08:00 UTC
+    - cron: "0 8 * * 1"
+  # Allow manual trigger for testing
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  generate-newsletter:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install pyyaml requests python-dateutil
+
+      - name: Generate newsletter and create GitHub Issue
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: python .github/scripts/generate_newsletter.py

--- a/.github/workflows/social-media.yml
+++ b/.github/workflows/social-media.yml
@@ -1,0 +1,52 @@
+name: Post to Social Media
+
+on:
+  push:
+    branches:
+      - gh-pages
+    paths:
+      - "_data/events.yml"
+      - "_data/talks.yml"
+      - "_data/news.yml"
+      - "_data/grants.yml"
+      - "_data/publist.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  post-social:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository (with history for diff)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install pyyaml requests tweepy python-dateutil
+
+      - name: Post new content to social media
+        env:
+          # Mastodon
+          MASTODON_INSTANCE_URL: ${{ secrets.MASTODON_INSTANCE_URL }}
+          MASTODON_ACCESS_TOKEN: ${{ secrets.MASTODON_ACCESS_TOKEN }}
+          # Bluesky
+          BLUESKY_HANDLE: ${{ secrets.BLUESKY_HANDLE }}
+          BLUESKY_APP_PASSWORD: ${{ secrets.BLUESKY_APP_PASSWORD }}
+          # X / Twitter (OAuth 1.0a)
+          TWITTER_API_KEY: ${{ secrets.TWITTER_API_KEY }}
+          TWITTER_API_SECRET: ${{ secrets.TWITTER_API_SECRET }}
+          TWITTER_ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}
+          TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
+          # LinkedIn
+          LINKEDIN_ACCESS_TOKEN: ${{ secrets.LINKEDIN_ACCESS_TOKEN }}
+          LINKEDIN_PERSON_URN: ${{ secrets.LINKEDIN_PERSON_URN }}
+          # Set to "true" to log messages without actually posting
+          DRY_RUN: ${{ vars.SOCIAL_DRY_RUN }}
+        run: python .github/scripts/post_social.py

--- a/_data/events.yml
+++ b/_data/events.yml
@@ -1,0 +1,31 @@
+# Events data file
+# Fields:
+#   date:        (required) "DD Month, YYYY"  — start date
+#   end_date:    (optional) "DD Month, YYYY"  — end date for multi-day events
+#   title:       (required) Event title
+#   type:        (required) seminar | workshop | conference | colloquium | other
+#   speaker:     (optional) Speaker name(s)
+#   location:    (optional) Room / venue
+#   link:        (optional) Registration or info URL
+#   description: (optional) Short plain-text description
+
+- date: "20 May, 2026"
+  title: "AI in Healthcare Workshop"
+  type: workshop
+  speaker: "Prof. Jane Smith (Imperial College London)"
+  location: "Room AG21, Northampton Square"
+  link: "https://www.city.ac.uk"
+  description: "A half-day workshop exploring AI applications in clinical decision support and medical imaging."
+
+- date: "5 June, 2026"
+  title: "NLP Summer Colloquium"
+  type: colloquium
+  location: "ELG09, Drysdale Building"
+  description: "Annual colloquium showcasing NLP research from the group and invited speakers."
+
+- date: "12 March, 2026"
+  title: "Trustworthy AI Seminar Series — Kick-off"
+  type: seminar
+  speaker: "Prof. Tweyde"
+  location: "Room AG21, Northampton Square"
+  description: "Launch of the new interdisciplinary seminar series on safety and explainability in AI systems."

--- a/_data/grants.yml
+++ b/_data/grants.yml
@@ -1,0 +1,33 @@
+# Grants data file
+# Fields:
+#   title:              (required) Grant/project title
+#   funder:             (required) Funding body (e.g. EPSRC, Innovate UK)
+#   funder_logo:        (optional) Logo filename placed in images/
+#   amount:             (optional) Award amount as string, e.g. "£450,000"
+#   pi:                 (required) Principal Investigator name
+#   co_investigators:   (optional) Comma-separated co-investigator names
+#   start_date:         (required) "YYYY/MM/DD"
+#   end_date:           (required) "YYYY/MM/DD" — used to determine active vs completed
+#   description:        (optional) Short project description
+#   link:               (optional) Project webpage URL
+#   status:             (required) active | completed
+
+- title: "Explainable Neural-Symbolic Reasoning for Clinical AI"
+  funder: "EPSRC"
+  amount: "£520,000"
+  pi: "Prof. Tweyde"
+  co_investigators: "Dr. Smith, Dr. Jones"
+  start_date: "2024/01/01"
+  end_date: "2027/03/31"
+  description: "Developing hybrid neural-symbolic architectures that can provide human-interpretable explanations for decisions in clinical AI applications."
+  link: "https://www.city.ac.uk"
+  status: active
+
+- title: "Audio Scene Understanding with Deep Learning"
+  funder: "Innovate UK"
+  amount: "£280,000"
+  pi: "Dr. Brown"
+  start_date: "2022/06/01"
+  end_date: "2025/05/31"
+  description: "Building robust models for environmental sound classification and source separation in real-world acoustic scenes."
+  status: completed

--- a/_data/talks.yml
+++ b/_data/talks.yml
@@ -1,0 +1,25 @@
+# Talks data file
+# Fields:
+#   date:        (required) "DD Month, YYYY"
+#   title:       (required) Talk title
+#   speaker:     (required) Speaker name
+#   affiliation: (optional) Speaker's institution
+#   abstract:    (optional) Short abstract
+#   slides_link: (optional) URL to slides
+#   video_link:  (optional) URL to recording
+#   host:        (optional) Host faculty member
+
+- date: "28 April, 2026"
+  title: "Attention Mechanisms Beyond Transformers"
+  speaker: "Dr. Alice Brown"
+  affiliation: "UCL"
+  abstract: "This talk surveys recent work on attention mechanisms outside the standard Transformer architecture, including state-space models and linear attention variants."
+  host: "Prof. Tweyde"
+
+- date: "10 February, 2026"
+  title: "Reinforcement Learning from Human Feedback: Theory and Practice"
+  speaker: "Dr. Marco Rossi"
+  affiliation: "DeepMind"
+  abstract: "An overview of RLHF methods used in modern language model alignment, with discussion of open theoretical questions."
+  video_link: "https://www.youtube.com"
+  host: "Prof. Tweyde"

--- a/_includes/events_upcoming.html
+++ b/_includes/events_upcoming.html
@@ -1,0 +1,47 @@
+{% assign today = 'now' | date: '%s' | plus: 0 %}
+{% assign grace = 86400 %}
+{% assign future_cutoff = today | minus: grace %}
+
+{% assign enriched = "" | split: "" %}
+{% for item in site.data.events %}
+  {% assign epoch = item.date | date_to_xmlschema | date: '%s' | plus: 0 %}
+  {% assign packed = epoch | append: "|||" | append: item.date | append: "|||" | append: item.title | append: "|||" | append: item.type | append: "|||" | append: item.link %}
+  {% assign enriched = enriched | push: packed %}
+{% endfor %}
+
+{% assign sorted = enriched | sort %}
+
+{% assign upcoming_count = 0 %}
+{% for entry in sorted %}
+  {% assign parts = entry | split: "|||" %}
+  {% assign epoch = parts[0] | plus: 0 %}
+  {% if epoch >= future_cutoff %}
+    {% assign upcoming_count = upcoming_count | plus: 1 %}
+  {% endif %}
+{% endfor %}
+
+{% if upcoming_count > 0 %}
+<div class="well">
+  <h3>Upcoming Events</h3>
+  {% assign shown = 0 %}
+  {% for entry in sorted %}
+    {% assign parts = entry | split: "|||" %}
+    {% assign epoch = parts[0] | plus: 0 %}
+    {% if epoch >= future_cutoff and shown < 3 %}
+      {% assign shown = shown | plus: 1 %}
+      <p>
+        {{ parts[1] }}<br>
+        {% if parts[4] and parts[4] != "" %}
+          <a href="{{ parts[4] }}"><strong>{{ parts[2] }}</strong></a>
+        {% else %}
+          <strong>{{ parts[2] }}</strong>
+        {% endif %}
+        {% if parts[3] and parts[3] != "" %}
+          <br><small style="color:#888; text-transform:capitalize;">{{ parts[3] }}</small>
+        {% endif %}
+      </p>
+    {% endif %}
+  {% endfor %}
+  <h4><a href="{{ site.url }}{{ site.baseurl }}/events.html">... see all Events</a></h4>
+</div>
+{% endif %}

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -8,16 +8,20 @@
 		<span class="icon-bar"></span>
 	  </button>
 	
-    <a class="navbar-brand" href="{{ site.url }}{{ site.baseurl }}/">Allan Lab @ Leiden &rarr; University of Munich (LMU)</a>
+    <a class="navbar-brand" href="{{ site.url }}{{ site.baseurl }}/">aiCentre@CSG</a>
 	</div>
 	<div class="collapse navbar-collapse" id="navbar-collapse-1">
 	  <ul class="nav navbar-nav navbar-right">
 		<li><a href="{{ site.url }}{{ site.baseurl }}/">Home</a></li>
-		<li><a href="{{ site.url }}{{ site.baseurl }}/team">Team</a></li>
+		<li><a href="{{ site.url }}{{ site.baseurl }}/research">Research Areas</a></li>
+		<li><a href="{{ site.url }}{{ site.baseurl }}/People">People</a></li>
 		<li><a href="{{ site.url }}{{ site.baseurl }}/vacancies">Vacancies</a></li>
 		<li><a href="{{ site.url }}{{ site.baseurl }}/publications">Publications</a></li>
-		<li><a href="{{ site.url }}{{ site.baseurl }}/research">Research</a></li>
-	<!-- li><a href="{{ site.url }}{{ site.baseurl }}/pictures">(Pics)</a></li> -->	
+		<li><a href="{{ site.url }}{{ site.baseurl }}/events.html">Events</a></li>
+		<li><a href="{{ site.url }}{{ site.baseurl }}/talks.html">Talks</a></li>
+		<li><a href="{{ site.url }}{{ site.baseurl }}/grants.html">Grants</a></li>
+
+	<!-- li><a href="{{ site.url }}{{ site.baseurl }}/pictures">(Pics)</a></li> -->
 	  </ul>
 	</div>
   </div>

--- a/_includes/news.html
+++ b/_includes/news.html
@@ -1,11 +1,60 @@
-
 <div class="well">
-<h4>News</h4>
+  <h3>News and Announcements</h3>
 
-{% for article in site.data.news limit:9 %}
-<p>{{ article.date }}<br>{{ article.headline | markdownify}}</p>
-{% endfor %}
+  {% assign today = 'now' | date: '%s' | plus: 0 %}
+  {% assign all_items = site.data.news %}
+  {% assign enriched = "" | split: "" %}
 
-<h4><a href="{{ site.url }}{{ site.baseurl }}/allnews.html">... see all News</a></h4>
+  {%- comment -%}
+  Convert each date string ("3 November, 2025") → epoch seconds
+  {%- endcomment -%}
+  {% for item in all_items %}
+    {% assign epoch = item.date | date_to_xmlschema | date: '%s' | plus: 0 %}
+    {% assign packed = epoch | append: "|||" | append: item.date | append: "|||" | append: item.headline %}
+    {% assign enriched = enriched | push: packed %}
+  {% endfor %}
 
-    </div>
+  {%- comment -%}
+  Synthesise recent publications (last 90 days) as news items
+  {%- endcomment -%}
+  {% assign ninety_days = 7776000 %}
+  {% assign paper_cutoff = today | minus: ninety_days %}
+  {% for pub in site.data.publist %}
+    {% assign pub_epoch = pub.date | date: '%s' | plus: 0 %}
+    {% if pub_epoch >= paper_cutoff %}
+      {% assign pub_display_date = pub.date | date: "%-d %B, %Y" %}
+      {% if pub.link.url and pub.link.url != "" %}
+        {% assign pub_headline = "New paper: [**" | append: pub.title | append: "**](" | append: pub.link.url | append: ") — " | append: pub.authors %}
+      {% else %}
+        {% assign pub_headline = "New paper: **" | append: pub.title | append: "** — " | append: pub.authors %}
+      {% endif %}
+      {% assign packed = pub_epoch | append: "|||" | append: pub_display_date | append: "|||" | append: pub_headline %}
+      {% assign enriched = enriched | push: packed %}
+    {% endif %}
+  {% endfor %}
+
+  {%- comment -%}
+  Sort numerically by epoch
+  {%- endcomment -%}
+  {% assign sorted = enriched | sort %}
+
+  {%- comment -%}
+  Loop in chronological order, show today and future (+1 day buffer)
+  {%- endcomment -%}
+  {% for entry in sorted %}
+    {% assign parts = entry | split: "|||" %}
+    {% assign epoch = parts[0] | plus: 0 %}
+    {% assign date = parts[1] %}
+    {% assign headline = parts[2] %}
+    {% assign buffer = 86400 %}
+    {% assign cutoff = today | minus: buffer %}
+    {% if epoch >= cutoff %}
+      <p>
+        {{ date }}<br>
+        {{ headline | markdownify }}
+      </p>
+    {% endif %}
+  {% endfor %}
+
+  <h4><a href="{{ site.url }}{{ site.baseurl }}/allnews.html">... see all News</a></h4>
+</div>

--- a/_layouts/homelay.html
+++ b/_layouts/homelay.html
@@ -3,10 +3,11 @@ layout: default
 ---
 
   <div id="homeid" class="col-sm-8">
-        <h1>Welcome to the Allan Lab</h1>
+        <h1>Welcome to the AI Centre@CSG</h1>
 
 	{{ content }}
   </div>
   <div id="newsid" class="col-sm-4" >
 	{% include news.html %}
+	{% include events_upcoming.html %}
   </div>

--- a/_pages/allnews.html
+++ b/_pages/allnews.html
@@ -1,0 +1,77 @@
+---
+title: "News and Announcements"
+layout: textlay
+excerpt: "AI Centre@CSG - City St George's, University of London"
+sitemap: false
+permalink: /allnews.html
+---
+
+<h1><strong>News and Announcements</strong></h1>
+
+{% assign today = 'now' | date: '%s' | plus: 0 %}
+{% assign grace = 86400 %}  <!-- 1-day buffer -->
+{% assign future_cutoff = today | minus: grace %}
+
+{% assign enriched = "" | split: "" %}
+
+{%- comment -%}
+Convert all YAML date strings ("3 November, 2025") into epoch seconds.
+{%- endcomment -%}
+{% for item in site.data.news %}
+  {% assign epoch = item.date | date_to_xmlschema | date: '%s' | plus: 0 %}
+  {% assign packed = epoch | append: "|||" | append: item.date | append: "|||" | append: item.headline %}
+  {% assign enriched = enriched | push: packed %}
+{% endfor %}
+
+{%- comment -%}
+Synthesise all publications as news items.
+{%- endcomment -%}
+{% for pub in site.data.publist %}
+  {% assign pub_epoch = pub.date | date: '%s' | plus: 0 %}
+  {% assign pub_display_date = pub.date | date: "%-d %B, %Y" %}
+  {% if pub.link.url and pub.link.url != "" %}
+    {% assign pub_headline = "New paper: [**" | append: pub.title | append: "**](" | append: pub.link.url | append: ") — " | append: pub.authors %}
+  {% else %}
+    {% assign pub_headline = "New paper: **" | append: pub.title | append: "** — " | append: pub.authors %}
+  {% endif %}
+  {% assign packed = pub_epoch | append: "|||" | append: pub_display_date | append: "|||" | append: pub_headline %}
+  {% assign enriched = enriched | push: packed %}
+{% endfor %}
+
+{% assign sorted = enriched | sort %}
+
+<h2>Upcoming Events & Announcements</h2>
+{% for entry in sorted %}
+  {% assign parts = entry | split: "|||" %}
+  {% assign epoch = parts[0] | plus: 0 %}
+  {% assign date = parts[1] %}
+  {% assign headline = parts[2] %}
+  {% if epoch >= future_cutoff %}
+    <div class="news-item" style="margin-bottom: 1.5em; padding-bottom: 1em; border-bottom: 1px solid #ddd;">
+      <p style="font-size: 0.95em; color: #666; margin-bottom: 0.3em;">
+        <strong>{{ date }}</strong>
+      </p>
+      <div style="font-size: 1.05em;">
+        {{ headline | markdownify }}
+      </div>
+    </div>
+  {% endif %}
+{% endfor %}
+
+<h2>Past News & Announcements</h2>
+{% for entry in sorted | reverse %}
+  {% assign parts = entry | split: "|||" %}
+  {% assign epoch = parts[0] | plus: 0 %}
+  {% assign date = parts[1] %}
+  {% assign headline = parts[2] %}
+  {% if epoch < future_cutoff %}
+    <div class="news-item" style="margin-bottom: 1.5em; padding-bottom: 1em; border-bottom: 1px solid #ddd;">
+      <p style="font-size: 0.95em; color: #666; margin-bottom: 0.3em;">
+        <strong>{{ date }}</strong>
+      </p>
+      <div style="font-size: 1.05em;">
+        {{ headline | markdownify }}
+      </div>
+    </div>
+  {% endif %}
+{% endfor %}

--- a/_pages/events.html
+++ b/_pages/events.html
@@ -1,0 +1,89 @@
+---
+title: "Events"
+layout: textlay
+excerpt: "AI Centre@CSG — Events"
+sitemap: true
+permalink: /events.html
+---
+
+<h1><strong>Events</strong></h1>
+
+<p>Workshops, seminars, conferences, and colloquia organised or co-organised by the AI Centre@CSG.</p>
+
+{% assign today = 'now' | date: '%s' | plus: 0 %}
+{% assign grace = 86400 %}
+{% assign future_cutoff = today | minus: grace %}
+
+{% assign enriched = "" | split: "" %}
+
+{% for item in site.data.events %}
+  {% assign epoch = item.date | date_to_xmlschema | date: '%s' | plus: 0 %}
+  {% assign packed = epoch | append: "|||" | append: item.date | append: "|||" | append: item.title | append: "|||" | append: item.type | append: "|||" | append: item.speaker | append: "|||" | append: item.location | append: "|||" | append: item.link | append: "|||" | append: item.description %}
+  {% assign enriched = enriched | push: packed %}
+{% endfor %}
+
+{% assign sorted = enriched | sort | reverse %}
+
+<h2>Upcoming Events</h2>
+{% assign has_upcoming = false %}
+{% for entry in sorted %}
+  {% assign parts = entry | split: "|||" %}
+  {% assign epoch = parts[0] | plus: 0 %}
+  {% if epoch >= future_cutoff %}
+    {% assign has_upcoming = true %}
+    <div class="news-item" style="margin-bottom: 1.5em; padding-bottom: 1em; border-bottom: 1px solid #ddd;">
+      <p style="font-size: 0.95em; color: #666; margin-bottom: 0.3em;">
+        <strong>{{ parts[1] }}</strong>
+        {% if parts[3] and parts[3] != "" %}
+          &nbsp;<span class="label label-info" style="font-size:0.8em; text-transform:capitalize;">{{ parts[3] }}</span>
+        {% endif %}
+      </p>
+      <p style="font-size: 1.05em; font-weight: bold; margin-bottom: 0.3em;">{{ parts[2] }}</p>
+      {% if parts[4] and parts[4] != "" %}
+        <p style="margin-bottom: 0.2em;"><strong>Speaker:</strong> {{ parts[4] }}</p>
+      {% endif %}
+      {% if parts[5] and parts[5] != "" %}
+        <p style="margin-bottom: 0.2em;"><strong>Location:</strong> {{ parts[5] }}</p>
+      {% endif %}
+      {% if parts[7] and parts[7] != "" %}
+        <p style="margin-bottom: 0.4em; color: #444;">{{ parts[7] }}</p>
+      {% endif %}
+      {% if parts[6] and parts[6] != "" %}
+        <a href="{{ parts[6] }}" class="btn btn-xs btn-primary" target="_blank" rel="noopener">More info</a>
+      {% endif %}
+    </div>
+  {% endif %}
+{% endfor %}
+{% unless has_upcoming %}<p><em>No upcoming events at the moment — check back soon.</em></p>{% endunless %}
+
+<h2>Past Events</h2>
+{% assign has_past = false %}
+{% for entry in sorted %}
+  {% assign parts = entry | split: "|||" %}
+  {% assign epoch = parts[0] | plus: 0 %}
+  {% if epoch < future_cutoff %}
+    {% assign has_past = true %}
+    <div class="news-item" style="margin-bottom: 1.5em; padding-bottom: 1em; border-bottom: 1px solid #ddd;">
+      <p style="font-size: 0.95em; color: #666; margin-bottom: 0.3em;">
+        <strong>{{ parts[1] }}</strong>
+        {% if parts[3] and parts[3] != "" %}
+          &nbsp;<span class="label label-default" style="font-size:0.8em; text-transform:capitalize;">{{ parts[3] }}</span>
+        {% endif %}
+      </p>
+      <p style="font-size: 1.05em; font-weight: bold; margin-bottom: 0.3em;">{{ parts[2] }}</p>
+      {% if parts[4] and parts[4] != "" %}
+        <p style="margin-bottom: 0.2em;"><strong>Speaker:</strong> {{ parts[4] }}</p>
+      {% endif %}
+      {% if parts[5] and parts[5] != "" %}
+        <p style="margin-bottom: 0.2em;"><strong>Location:</strong> {{ parts[5] }}</p>
+      {% endif %}
+      {% if parts[7] and parts[7] != "" %}
+        <p style="margin-bottom: 0.4em; color: #444;">{{ parts[7] }}</p>
+      {% endif %}
+      {% if parts[6] and parts[6] != "" %}
+        <a href="{{ parts[6] }}" class="btn btn-xs btn-default" target="_blank" rel="noopener">More info</a>
+      {% endif %}
+    </div>
+  {% endif %}
+{% endfor %}
+{% unless has_past %}<p><em>No past events recorded yet.</em></p>{% endunless %}

--- a/_pages/grants.html
+++ b/_pages/grants.html
@@ -1,0 +1,81 @@
+---
+title: "Grants & Funding"
+layout: textlay
+excerpt: "AI Centre@CSG — Grants and Funding"
+sitemap: true
+permalink: /grants.html
+---
+
+<h1><strong>Grants &amp; Funding</strong></h1>
+
+<p>Research grants and funded projects at the AI Centre@CSG.</p>
+
+{% assign today = 'now' | date: '%s' | plus: 0 %}
+
+<h2>Active Grants</h2>
+{% assign has_active = false %}
+{% for grant in site.data.grants %}
+  {% if grant.status == "active" %}
+    {% assign has_active = true %}
+    <div class="news-item" style="margin-bottom: 1.8em; padding-bottom: 1em; border-bottom: 1px solid #ddd;">
+      <p style="font-size: 1.05em; font-weight: bold; margin-bottom: 0.3em;">
+        {% if grant.link and grant.link != "" %}
+          <a href="{{ grant.link }}" target="_blank" rel="noopener">{{ grant.title }}</a>
+        {% else %}
+          {{ grant.title }}
+        {% endif %}
+      </p>
+      <p style="margin-bottom: 0.2em;">
+        <strong>Funder:</strong> {{ grant.funder }}
+        {% if grant.amount and grant.amount != "" %} &nbsp;|&nbsp; <strong>Amount:</strong> {{ grant.amount }}{% endif %}
+      </p>
+      <p style="margin-bottom: 0.2em;">
+        <strong>PI:</strong> {{ grant.pi }}
+        {% if grant.co_investigators and grant.co_investigators != "" %}
+          &nbsp;|&nbsp; <strong>Co-Is:</strong> {{ grant.co_investigators }}
+        {% endif %}
+      </p>
+      <p style="margin-bottom: 0.2em; font-size: 0.9em; color: #666;">
+        {{ grant.start_date | date: "%B %Y" }} – {{ grant.end_date | date: "%B %Y" }}
+      </p>
+      {% if grant.description and grant.description != "" %}
+        <p style="margin-bottom: 0; color: #444;">{{ grant.description }}</p>
+      {% endif %}
+    </div>
+  {% endif %}
+{% endfor %}
+{% unless has_active %}<p><em>No active grants listed yet.</em></p>{% endunless %}
+
+<h2>Completed Grants</h2>
+{% assign has_completed = false %}
+{% for grant in site.data.grants %}
+  {% if grant.status == "completed" %}
+    {% assign has_completed = true %}
+    <div class="news-item" style="margin-bottom: 1.8em; padding-bottom: 1em; border-bottom: 1px solid #ddd;">
+      <p style="font-size: 1.05em; font-weight: bold; margin-bottom: 0.3em;">
+        {% if grant.link and grant.link != "" %}
+          <a href="{{ grant.link }}" target="_blank" rel="noopener">{{ grant.title }}</a>
+        {% else %}
+          {{ grant.title }}
+        {% endif %}
+      </p>
+      <p style="margin-bottom: 0.2em;">
+        <strong>Funder:</strong> {{ grant.funder }}
+        {% if grant.amount and grant.amount != "" %} &nbsp;|&nbsp; <strong>Amount:</strong> {{ grant.amount }}{% endif %}
+      </p>
+      <p style="margin-bottom: 0.2em;">
+        <strong>PI:</strong> {{ grant.pi }}
+        {% if grant.co_investigators and grant.co_investigators != "" %}
+          &nbsp;|&nbsp; <strong>Co-Is:</strong> {{ grant.co_investigators }}
+        {% endif %}
+      </p>
+      <p style="margin-bottom: 0.2em; font-size: 0.9em; color: #666;">
+        {{ grant.start_date | date: "%B %Y" }} – {{ grant.end_date | date: "%B %Y" }}
+      </p>
+      {% if grant.description and grant.description != "" %}
+        <p style="margin-bottom: 0; color: #444;">{{ grant.description }}</p>
+      {% endif %}
+    </div>
+  {% endif %}
+{% endfor %}
+{% unless has_completed %}<p><em>No completed grants listed yet.</em></p>{% endunless %}

--- a/_pages/talks.html
+++ b/_pages/talks.html
@@ -1,0 +1,78 @@
+---
+title: "Talks"
+layout: textlay
+excerpt: "AI Centre@CSG — Talks"
+sitemap: true
+permalink: /talks.html
+---
+
+<h1><strong>Talks</strong></h1>
+
+<p>Invited talks and guest lectures hosted by the AI Centre@CSG.</p>
+
+{% assign today = 'now' | date: '%s' | plus: 0 %}
+{% assign grace = 86400 %}
+{% assign future_cutoff = today | minus: grace %}
+
+{% assign enriched = "" | split: "" %}
+
+{% for item in site.data.talks %}
+  {% assign epoch = item.date | date_to_xmlschema | date: '%s' | plus: 0 %}
+  {% assign packed = epoch | append: "|||" | append: item.date | append: "|||" | append: item.title | append: "|||" | append: item.speaker | append: "|||" | append: item.affiliation | append: "|||" | append: item.abstract | append: "|||" | append: item.slides_link | append: "|||" | append: item.video_link | append: "|||" | append: item.host %}
+  {% assign enriched = enriched | push: packed %}
+{% endfor %}
+
+{% assign sorted = enriched | sort | reverse %}
+
+<h2>Upcoming Talks</h2>
+{% assign has_upcoming = false %}
+{% for entry in sorted %}
+  {% assign parts = entry | split: "|||" %}
+  {% assign epoch = parts[0] | plus: 0 %}
+  {% if epoch >= future_cutoff %}
+    {% assign has_upcoming = true %}
+    <div class="news-item" style="margin-bottom: 1.5em; padding-bottom: 1em; border-bottom: 1px solid #ddd;">
+      <p style="font-size: 0.95em; color: #666; margin-bottom: 0.3em;"><strong>{{ parts[1] }}</strong></p>
+      <p style="font-size: 1.05em; font-weight: bold; margin-bottom: 0.3em;">{{ parts[2] }}</p>
+      <p style="margin-bottom: 0.2em;">
+        <strong>{{ parts[3] }}</strong>{% if parts[4] and parts[4] != "" %}, {{ parts[4] }}{% endif %}
+      </p>
+      {% if parts[5] and parts[5] != "" %}
+        <p style="margin-bottom: 0.4em; color: #444; font-style: italic;">{{ parts[5] }}</p>
+      {% endif %}
+      {% if parts[8] and parts[8] != "" %}
+        <p style="margin-bottom: 0.4em; font-size: 0.9em; color: #666;">Host: {{ parts[8] }}</p>
+      {% endif %}
+    </div>
+  {% endif %}
+{% endfor %}
+{% unless has_upcoming %}<p><em>No upcoming talks at the moment — check back soon.</em></p>{% endunless %}
+
+<h2>Past Talks</h2>
+{% assign has_past = false %}
+{% for entry in sorted %}
+  {% assign parts = entry | split: "|||" %}
+  {% assign epoch = parts[0] | plus: 0 %}
+  {% if epoch < future_cutoff %}
+    {% assign has_past = true %}
+    <div class="news-item" style="margin-bottom: 1.5em; padding-bottom: 1em; border-bottom: 1px solid #ddd;">
+      <p style="font-size: 0.95em; color: #666; margin-bottom: 0.3em;"><strong>{{ parts[1] }}</strong></p>
+      <p style="font-size: 1.05em; font-weight: bold; margin-bottom: 0.3em;">{{ parts[2] }}</p>
+      <p style="margin-bottom: 0.2em;">
+        <strong>{{ parts[3] }}</strong>{% if parts[4] and parts[4] != "" %}, {{ parts[4] }}{% endif %}
+      </p>
+      {% if parts[5] and parts[5] != "" %}
+        <p style="margin-bottom: 0.4em; color: #444; font-style: italic;">{{ parts[5] }}</p>
+      {% endif %}
+      <p style="margin-bottom: 0.4em;">
+        {% if parts[6] and parts[6] != "" %}
+          <a href="{{ parts[6] }}" class="btn btn-xs btn-default" target="_blank" rel="noopener">Slides</a>
+        {% endif %}
+        {% if parts[7] and parts[7] != "" %}
+          <a href="{{ parts[7] }}" class="btn btn-xs btn-default" target="_blank" rel="noopener">Recording</a>
+        {% endif %}
+      </p>
+    </div>
+  {% endif %}
+{% endfor %}
+{% unless has_past %}<p><em>No past talks recorded yet.</em></p>{% endunless %}


### PR DESCRIPTION
## Summary

- 3 new data schemas: `_data/events.yml`, `talks.yml`, `grants.yml`
- 3 new pages: Events, Talks, Grants (upcoming/past split)
- Papers from `publist.yml` auto-appear in the news feed
- Homepage sidebar: Upcoming Events widget
- Nav links for Events, Talks, Grants

## Automation (GitHub Actions)
- `newsletter. weekly GitHub Issue digest (Mondays 08:00 UTC)yml` 
- `social-media. posts new `_data/` entries to Mastodon, Bluesky, X, LinkedInyml` 

## Setup needed
1. Add repository secrets for social media platforms
2. Set `SOCIAL_DRY_RUN=true` to test without posting
3. Update `SITE_URL` in both Python scripts

Generated with Claude Code